### PR TITLE
Enable Linux builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2022, macos-11] #, ubuntu-22.04]
+        os: [windows-2022, macos-11, ubuntu-22.04]
         addrsize: ["64"]
         include:
           - os: windows-2022

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -104,6 +104,7 @@ case "$AUTOBUILD_PLATFORM" in
         pushd "$OGG_SOURCE_DIR"
         opts="-m$AUTOBUILD_ADDRSIZE $LL_BUILD_RELEASE"
         plainopts="$(remove_cxxstd $opts)"
+        autoreconf -fi
         CFLAGS="$plainopts" CXXFLAGS="$opts" ./configure --prefix="$stage"
         make
         make install
@@ -111,6 +112,7 @@ case "$AUTOBUILD_PLATFORM" in
         
         pushd "$VORBIS_SOURCE_DIR"
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$stage/lib"
+        autoreconf -fi
         CFLAGS="$plainopts" CXXFLAGS="$opts" ./configure --prefix="$stage"
         make
         make install


### PR DESCRIPTION
- Enable ubuntu-22.04 runner
- During build run autoreconf to get a configure cmd compatible with Ubuntu 22.04