### PR TITLE
Remove windows debug build and fix symbol generation

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -113,7 +113,6 @@
           </map>
           <key>manifest</key>
           <array>
-            <string>lib/debug/*.lib</string>
             <string>lib/release/*.lib</string>
           </array>
           <key>name</key>


### PR DESCRIPTION
General housekeeping:
* Fix macos deploy targeting to use version from variables
* Fix windows libraries to include debug symbols